### PR TITLE
Fixed deprecation error

### DIFF
--- a/rpmlint.rb
+++ b/rpmlint.rb
@@ -8,7 +8,7 @@ class Rpmlint < Formula
   depends_on "libmagic" => [:recommended, "with-python"]
   depends_on "enchant" => [:recommended, "with-python"]
   depends_on "xz"
-  depends_on :python
+  depends_on "python"
 
   def install
     inreplace "rpmlint", "/usr/share/rpmlint/config", "#{HOMEBREW_PREFIX}/etc/rpmlint/config"


### PR DESCRIPTION
```
Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/mckern/homebrew-packaging-tools/rpmlint.rb:11:in `<class:Rpmlint>'
Please report this to the mckern/packaging-tools tap!
```